### PR TITLE
enable threading for scraping scripts

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -89,8 +89,8 @@ if (cluster.isMaster) {
 
     }
 
-    cluster.on('exit', function (worker, code, signal) {
-        console.log('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal);
+    cluster.on('exit', function (deadworker, code, signal) {
+        console.log('Worker ' + deadworker.process.pid + ' died with code: ' + code + ', and signal: ' + signal);
         var scriptToExecute = scriptsArray.pop();
         if (scriptToExecute) {
             // if a worker dies and there are still remaining scripts, spawn a new worker and let him execute it
@@ -102,7 +102,7 @@ if (cluster.isMaster) {
 
     cluster.on('message', function (m) {
         scrapingcounter--;
-        if (scrapingcounter == 0) {
+        if (scrapingcounter === 0) {
             //once all scraping scripts finished, populate the db
             console.log("all done");
             populateDB();
@@ -110,7 +110,7 @@ if (cluster.isMaster) {
     });
 }
 else {
-    process.on('message', function (scriptToExecute) {
+    process.on("message", function (scriptToExecute) {
         console.log("Worker is executing " + scriptToExecute);
         var script = require(scriptToExecute);
         script(function () {
@@ -134,10 +134,10 @@ function populateDB() {
             const artists = context.models.artists;
             const artistspath = path.join(__dirname, "scrapedoutput", "artists")
             fs.readdir(artistspath, (err, files) => {
-              if (err) {
-                        console.log(err);
-                        return;
-                    }
+                if (err) {
+                    console.log(err);
+                    return;
+                }
                 files.forEach(file => {
                     //for each file, read  it and do bulk create
                     fs.readFile(path.join(artistspath, file), function (err, data) {
@@ -146,7 +146,6 @@ function populateDB() {
                                 console.log("Created artist entries for " + file);
                             }).catch(function (error) {
                             console.log("error: " + error);
-
                         })
                     })
                 });
@@ -157,10 +156,10 @@ function populateDB() {
             const works = context.models.works;
             const workspath = path.join(__dirname, "scrapedoutput", "works")
             fs.readdir(workspath, (err, files) => {
-              if (err) {
-                        console.log(err);
-                        return;
-                    }
+                if (err) {
+                    console.log(err);
+                    return;
+                }
                 files.forEach(file => {
                     //for each file, read  it and do bulk create
                     fs.readFile(path.join(workspath, file), function (err, data) {
@@ -169,10 +168,7 @@ function populateDB() {
                                 console.log("Created work entries for " + file);
                             }).catch(function (error) {
                             console.log("error: " + error);
-
-                            })
-
-                        
+                        })
                     })
                 });
             });
@@ -182,10 +178,10 @@ function populateDB() {
             const releases = context.models.releases;
             const releasespath = path.join(__dirname, "scrapedoutput", "releases")
             fs.readdir(releasespath, (err, files) => {
-              if (err) {
-                        console.log(err);
-                        return;
-                    }
+                if (err) {
+                    console.log(err);
+                    return;
+                }
                 files.forEach(file => {
                     //for each file, read  it and do bulk create
                     fs.readFile(path.join(releasespath, file), function (err, data) {
@@ -194,9 +190,6 @@ function populateDB() {
                                 console.log("Created release entries for " + file);
                             }).catch(function (error) {
                             console.log("error: " + error);
-
-                
-                
                         })
                     })
                 });

--- a/cli.js
+++ b/cli.js
@@ -1,186 +1,191 @@
-/*
- to setup your own docker postgres db, install docker
- then in cmd/terminal, type:
- docker run -it --name my-postgres -p 5432:5432 postgres
-
- This will run your postgres db locally.
- With "docker ps -a" you can see all of your containers.
- Your my-postgres container should already be running. you can later stop and start it with "docker stop my-postgres" and
- "docker start my-postgres"
-
- Next, open pgadmin, right-click on servers on the left side, click on properties (and define a name if you haven't already).
- There in the second ribbon, set hostname as "localhost" and click save. You should now be connected to your postgres db.
-
- Now, you can execute this script. Navigate to this folder, in my case:
- cd git-repo
- Then execute it:
- node cli.js -s test
- This will add the scripts in the /testscripts folder and execute them. The dbpedia_musicians_nationality is changed such
- that it currently only fetches Frank Zappa and writes it to the output file.
- If everything worked correctly, CONGRATULATIONS! :D This entry should now be added to the db. You can check the artists
- table in pgadmin Servers->PSQL->Databases->postgres->schemas->public->tables->artists->
- rightclick and select "View Data ->View all data". Easy, right!?
- (If the script was successful but you cannot see any entries, you might need to restart pgadmin)
-
-
-
-
- THE NEXT STEPS TO IMPROVE THE SCRIPT:
-
-
- One would need to add a process.send to every script once its output file is written (see /testscripts/dbpedia_musicians_nationality.js)
-
-
- the "fs.readFile" in the populateDB function currently just gets the json file "testscripts/dbpedia_test.json". This would need to be solved
- dynamically. Either find all .json files in subfolders OR save all json outputfiles in one folder and then access them (second solution is
- probably better)
-
-
-
- */
 const commander = require('commander');
-const cp = require('child_process');
 const path = require('path');
 const fs = require('fs');
-//const path      = require('path');
-/*const parser    = require(path.resolve(__dirname,'parser'));
- const dataGridRenderer    = require(path.resolve(__dirname,'dataGridRenderer'));*/
-
-commander
-    .option('-s, --script [script]', 'Define the scripts that should be executed', /^(dbpedia|worldcat|musicbrainz|allmusic|test)$/i)
-    .option('-p, --postgres [postgres] ', 'Set the connection string to connect to the postgres db.')
-    .parse(process.argv);
-
-const script = commander.script || process.env.s;
-
-const postgresCS = commander.postgres || process.env.p;
-
+const cluster = require('cluster');
 var scriptsArray = [];
-if (script == "dbpedia") {
-    console.log("Adding dbpedia scripts");
-    scriptsArray.push("./dbpedia/dbpedia_Classical_musicians_by_century.js",
-        "./dbpedia/dbpedia_Classical_musicians_by_instrument.js",
-        "./dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js",
-        './dbpedia/dbpedia_Classical_musicians_by_nationality.js',
-        "./dbpedia/dbPedia_Composers.js"
-    );
-}
-if (script == "worldcat") {
-    console.log("Adding worldcat scripts");
-    scriptsArray.push("./worldcat/worldcat.js"
-    );
-}
-if (script == "musicbrainz") {
-    console.log("Adding musicbrainz scripts");
-    scriptsArray.push("./musicbrainz/scrapeArtists/server.js",
-        "./musicbrainz/scrapeRecordings/server.js",
-        "./musicbrainz/scrapeReleases/server.js",
-        "./musicbrainz/scrapeWorks/server.js",
-        "./musicbrainz/scrapeIDArtists/server.js",
-        "./musicbrainz/RecordingsArtistsID/app.js",
-        "./musicbrainz/DataForSequelizeAPI/app2.js",
-        "./musicbrainz/PutJSONTogether/app.js"
-    );
-}
-if (script == "allmusic") {
-    console.log("Adding almusic scripts");
-    scriptsArray.push("./allmusic/allMusicScript.js"
-    );
-}
-if (script == "test") {
-    console.log("Adding test scripts");
-    scriptsArray.push("./testscripts/test.js",
-        "./testscripts/test2.js",
-        "./testscripts/test3.js",
-        "./testscripts/dbpedia_musicians_nationality.js"
-    );
-}
-var arrayLength = scriptsArray.length;
-var cpCounter = 0;
-for (var i = 0; i < arrayLength; i++) {
-    var scriptToExecute = scriptsArray[i];
-    //this will create a child process for every script
-    const n = cp.fork(scriptToExecute);
+var script, postgresCS;
+if (cluster.isMaster) {
 
-    //once the script is done, it should send a message back to the main process
-    n.on('message', function (m) {
-        cpCounter++;
-        console.log('child process finished:', m);
-        //once all scripts are executed, continue with populating the db
-        if (cpCounter == arrayLength) {
+    commander
+        .option('-s, --script [script]', 'Define the scripts that should be executed', /^(dbpedia|worldcat|musicbrainz|allmusic|test)$/i)
+        .option('-d, --database [database] ', 'Set the connection string to connect to the database.')
+        .option('-t, --threads [threads] ', 'Set the amount of worker threads that should be spawned.')
+        .parse(process.argv);
+
+    script = commander.script || process.env.s;
+
+    postgresCS = commander.database || process.env.d;
+
+
+    if (script == "dbpedia") {
+        console.log("Adding dbpedia scripts");
+        scriptsArray.push("./dbpedia/dbpedia_Classical_musicians_by_century.js",
+            "./dbpedia/dbpedia_Classical_musicians_by_instrument.js",
+            "./dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js",
+            './dbpedia/dbpedia_Classical_musicians_by_nationality.js',
+            "./dbpedia/dbPedia_Composers.js"
+        );
+
+    }
+    if (script == "worldcat") {
+        console.log("Adding worldcat scripts");
+        scriptsArray.push("./worldcat/worldcat.js"
+        );
+    }
+    if (script == "musicbrainz") {
+        console.log("Adding musicbrainz scripts");
+        scriptsArray.push("./musicbrainz/scrapeArtists/server.js",
+            "./musicbrainz/scrapeRecordings/server.js",
+            "./musicbrainz/scrapeReleases/server.js",
+            "./musicbrainz/scrapeWorks/server.js",
+            "./musicbrainz/scrapeIDArtists/server.js",
+            "./musicbrainz/RecordingsArtistsID/app.js",
+            "./musicbrainz/DataForSequelizeAPI/app2.js",
+            "./musicbrainz/PutJSONTogether/app.js"
+        );
+    }
+    if (script == "allmusic") {
+        console.log("Adding almusic scripts");
+        scriptsArray.push("./allmusic/allMusicScript.js"
+        );
+    }
+    if (script == "test") {
+        console.log("Adding test scripts");
+        scriptsArray.push("./testscripts/test.js",
+            "./testscripts/test2.js",
+            "./testscripts/test3.js",
+            "./testscripts/dbpedia_musicians_nationality.js"
+        );
+    }
+
+
+    var cpus = require('os').cpus().length;
+    var numWorkers;
+
+    if (commander.threads) {
+        if (commander.threads > cpus) {
+            console.log("The number of your specified threads exceeds available cpus, reducing it to " + cpus);
+            numWorkers = cpus;
+        }
+        else {
+            console.log("Setting number of threads to " + commander.threads);
+            numWorkers = commander.threads;
+        }
+    }
+    else {
+        console.log("Setting number of threads to maximum of " + cpus);
+        numWorkers = cpus;
+    }
+
+    var scrapingcounter = scriptsArray.length;
+    console.log('Master cluster setting up ' + numWorkers + ' workers...');
+    for (var i = 0; i < numWorkers; i++) {
+        var worker = cluster.fork();
+        var scriptToExecute = scriptsArray.pop();
+        if (scriptToExecute) {
+            //let worker execute the scrape script
+            worker.send(scriptToExecute);
+        }
+
+    }
+
+    cluster.on('exit', function (worker, code, signal) {
+        console.log('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal);
+        var scriptToExecute = scriptsArray.pop();
+        if (scriptToExecute) {
+            // if a worker dies and there are still remaining scripts, spawn a new worker and let him execute it
+            var worker = cluster.fork();
+            worker.send(scriptToExecute);
+        }
+    });
+
+
+    cluster.on('message', function (m) {
+        scrapingcounter--;
+        if (scrapingcounter == 0) {
+            //once all scraping scripts finished, populate the db
+            console.log("all done");
             populateDB();
         }
-    })
-    ;
+    });
+}
+else {
+    process.on('message', function (scriptToExecute) {
+        console.log("Worker is executing " + scriptToExecute);
+        var script = require(scriptToExecute);
+        script(function () {
+            console.log(scriptToExecute + " finished successfully");
+            process.send("done");
+            process.exit();
+        })
+
+    });
 
 }
-;
 
 function populateDB() {
     console.log("Starting to populate db");
 
     require(path.join(__dirname, "api", "database.js")).connect(postgresCS, function (context) {
 
-        const api = require("./loadModules.js")(context, function () {
-            context.sequelize.sync({force: true}).then(function () {
+        context.sequelize.sync({force: true}).then(function () {
 
-                // bulk create all artists
-                const artists = context.component('models').module('artists');
-                const artistspath = path.join(__dirname, "scrapedoutput", "artists")
-                fs.readdir(artistspath, (err, files) => {
-                    files.forEach(file => {
-                        //for each file, read  it and do bulk create
-                        fs.readFile(path.join(artistspath, file), function (err, data) {
-                            artists.bulkCreate(JSON.parse(data))
-                                .then(function () {
-                                    console.log("Created artist entries for " + file);
-                                }).catch(function (error) {
-                                console.log("error: " + error);
-                            })
+            // bulk create all artists
+            const artists = context.models.artists;
+            const artistspath = path.join(__dirname, "scrapedoutput", "artists")
+            fs.readdir(artistspath, (err, files) => {
+                files.forEach(file => {
+                    //for each file, read  it and do bulk create
+                    fs.readFile(path.join(artistspath, file), function (err, data) {
+                        artists.bulkCreate(JSON.parse(data))
+                            .then(function () {
+                                console.log("Created artist entries for " + file);
+                            }).catch(function (error) {
+                            console.log("error: " + error);
                         })
-                    });
+                    })
                 });
-
-                // bulk create all works
-                const works = context.component('models').module('works');
-                const workspath = path.join(__dirname, "scrapedoutput", "works")
-                fs.readdir(workspath, (err, files) => {
-                    files.forEach(file => {
-                        //for each file, read  it and do bulk create
-                        fs.readFile(path.join(workspath, file), function (err, data) {
-                            works.bulkCreate(JSON.parse(data))
-                                .then(function () {
-                                    console.log("Created work entries for " + file);
-                                }).catch(function (error) {
-                                console.log("error: " + error);
-                            })
-                        })
-                    });
-                });
-
-                // bulk create all releases
-                const releases = context.component('models').module('releases');
-                const releasespath = path.join(__dirname, "scrapedoutput", "releases")
-                fs.readdir(releasespath, (err, files) => {
-                    files.forEach(file => {
-                        //for each file, read  it and do bulk create
-                        fs.readFile(path.join(releasespath, file), function (err, data) {
-                            releases.bulkCreate(JSON.parse(data))
-                                .then(function () {
-                                    console.log("Created release entries for " + file);
-                                }).catch(function (error) {
-                                console.log("error: " + error);
-                            })
-                        })
-                    });
-                });
-
-
-            }).catch(function (error) {
-                console.error("There was an error while syncronizing the tables between the application and the database.");
-                console.error(error);
-                process.exit(2);
             });
+
+            // bulk create all works
+            const works = context.models.works;
+            const workspath = path.join(__dirname, "scrapedoutput", "works")
+            fs.readdir(workspath, (err, files) => {
+                files.forEach(file => {
+                    //for each file, read  it and do bulk create
+                    fs.readFile(path.join(workspath, file), function (err, data) {
+                        works.bulkCreate(JSON.parse(data))
+                            .then(function () {
+                                console.log("Created work entries for " + file);
+                            }).catch(function (error) {
+                            console.log("error: " + error);
+                        })
+                    })
+                });
+            });
+
+            // bulk create all releases
+            const releases = context.models.releases;
+            const releasespath = path.join(__dirname, "scrapedoutput", "releases")
+            fs.readdir(releasespath, (err, files) => {
+                files.forEach(file => {
+                    //for each file, read  it and do bulk create
+                    fs.readFile(path.join(releasespath, file), function (err, data) {
+                        releases.bulkCreate(JSON.parse(data))
+                            .then(function () {
+                                console.log("Created release entries for " + file);
+                            }).catch(function (error) {
+                            console.log("error: " + error);
+                        })
+                    })
+                });
+            });
+
+
+        }).catch(function (error) {
+            console.error("There was an error while syncronizing the tables between the application and the database.");
+            console.error(error);
+            process.exit(2);
         });
 
 

--- a/dbpedia/dbPedia_Composers.js
+++ b/dbpedia/dbPedia_Composers.js
@@ -99,4 +99,4 @@ module.exports = function (returnToMaster) {
         });
     }
 
-}
+};

--- a/dbpedia/dbPedia_Composers.js
+++ b/dbpedia/dbPedia_Composers.js
@@ -1,99 +1,102 @@
-const fs = require('fs');
-const request = require('request');
-const cheerio = require('cheerio');
-const sleep = require('system-sleep');
-var jsesc = require('jsesc');
-const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
+module.exports = function (returnToMaster) {
+    const fs = require('fs');
+    const request = require('request');
+    const cheerio = require('cheerio');
+    const sleep = require('system-sleep');
+    var jsesc = require('jsesc');
+    const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
 
-var newObj = [];
-var url = [],
-    link = [];
-url.push('http://dbpedia.org/page/Category:17th-century_classical_composers');
-url.push('http://dbpedia.org/page/Category:18th-century_classical_composers');
+    var newObj = [];
+    var url = [],
+        link = [];
+    url.push('http://dbpedia.org/page/Category:17th-century_classical_composers');
+    url.push('http://dbpedia.org/page/Category:18th-century_classical_composers');
 
-console.log("---dbPedia_Composers.js started!---")
+    console.log("---dbPedia_Composers.js started!---")
 
-var counter = 0;
-url.forEach(function (value) {
-    getURL(value, function () {
-        counter++;
-        if (counter == url.length) {
-            fs.writeFileSync('./scrapedoutput/artists/dbPedia_Composers.json', JSON.stringify(newObj), 'utf-8');
-            process.send("done dbPedia_Composers.js");
-        }
-    });
-});
-
-
-function getURL(value, callback) {
-    request(jsesc(value), function (error, response, html) {
-        if (error) {
-            console.log("dbPedia_Composers.js getURL: " + error);
-            return
-        }
-        var $ = cheerio.load(html);
-        $('a[rev="dct:subject"]').each(function (i, element) {
-            var a = $(this);
-            var queryURL = a.attr('href');
-            link.push(queryURL);
+    var counter = 0;
+    url.forEach(function (value) {
+        getURL(value, function () {
+            counter++;
+            if (counter == url.length) {
+                fs.writeFileSync('./scrapedoutput/artists/dbPedia_Composers.json', JSON.stringify(newObj), 'utf-8');
+                returnToMaster();
+            }
         });
-        link.forEach(function (value) {
-            getArtist(value);
-            sleep(1000);
-        });
-
-        callback();
-
     });
-}
-
-function getArtist(source_link) {
-    request(jsesc(source_link), function (error, response, html) {
-
-        if (error) {
-            console.log("dbPedia_Composers.js getArtist: " + error);
-            return
-        }
-        var $ = cheerio.load(html);
-
-        //name
-        name = $('span[property="dbp:name"]').text();
-        if (!name) {
-            var name = (replaceURLAndUnderscore(source_link)).split("(");
-            name = name[0].trim();
-        }
-        var nationality = $('span[property="dbo:nationality"]').text().trim();
-        if (nationality.length == 0)
-            nationality = null;
 
 
-        var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
-
-        var scrapedData = scrapedbpediaProperties($);
-
-        //only add artist if he hasn't been added
-        if (!newObj.some(function (element) {
-                return element.source_link == source_link;
-            })) {
-            newObj.push({
-                name: name,
-                artist_type: 'composer',
-                nationality: nationality,
-                source_link: source_link,
-                dateOfBirth: scrapedData.dateOfBirth,
-                dateOfDeath: scrapedData.dateOfDeath,
-                placeOfBirth: scrapedData.placeOfBirth,
-                placeOfDeath: scrapedData.placeOfDeath,
-                instrument: scrapedData.instrument,
-                pseudonym: scrapedData.pseudonym,
-                work: scrapedData.work,
-                release: scrapedData.release,
-                tags: scrapedData.tags,
-                wiki_link: scrapedData.wiki_link,
-                wiki_pageid: scrapedData.wiki_pageid
+    function getURL(value, callback) {
+        request(jsesc(value), function (error, response, html) {
+            if (error) {
+                console.log("dbPedia_Composers.js getURL: " + error);
+                return
+            }
+            var $ = cheerio.load(html);
+            $('a[rev="dct:subject"]').each(function (i, element) {
+                var a = $(this);
+                var queryURL = a.attr('href');
+                link.push(queryURL);
             });
-        }
+            link.forEach(function (value) {
+                getArtist(value);
+                sleep(1000);
+            });
 
-    });
+            callback();
+
+        });
+    }
+
+    function getArtist(source_link) {
+        console.log("dbPedia_Composers.js scraping artist");
+        request(jsesc(source_link), function (error, response, html) {
+
+            if (error) {
+                console.log("dbPedia_Composers.js getArtist: " + error);
+                return
+            }
+            var $ = cheerio.load(html);
+
+            //name
+            name = $('span[property="dbp:name"]').text();
+            if (!name) {
+                var name = (replaceURLAndUnderscore(source_link)).split("(");
+                name = name[0].trim();
+            }
+            var nationality = $('span[property="dbo:nationality"]').text().trim();
+            if (nationality.length == 0)
+                nationality = null;
+
+
+            var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+
+            var scrapedData = scrapedbpediaProperties($);
+
+            //only add artist if he hasn't been added
+            if (!newObj.some(function (element) {
+                    return element.source_link == source_link;
+                })) {
+                newObj.push({
+                    name: name,
+                    artist_type: 'composer',
+                    nationality: nationality,
+                    source_link: source_link,
+                    dateOfBirth: scrapedData.dateOfBirth,
+                    dateOfDeath: scrapedData.dateOfDeath,
+                    placeOfBirth: scrapedData.placeOfBirth,
+                    placeOfDeath: scrapedData.placeOfDeath,
+                    instrument: scrapedData.instrument,
+                    pseudonym: scrapedData.pseudonym,
+                    work: scrapedData.work,
+                    release: scrapedData.release,
+                    tags: scrapedData.tags,
+                    wiki_link: scrapedData.wiki_link,
+                    wiki_pageid: scrapedData.wiki_pageid
+                });
+            }
+
+        });
+    }
+
 }
-

--- a/dbpedia/dbpedia_Classical_musicians_by_century.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_century.js
@@ -1,99 +1,103 @@
 /////////////////////EXTRACTS 21st,20th,19th,18th and 17th Century classical musicians///////////////
-var fs = require('fs');
-var sleep = require('system-sleep');
-var request = require("request");
-var cheerio = require('cheerio');
-var jsesc = require('jsesc');
-const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
+module.exports = function (returnToMaster) {
+    var fs = require('fs');
+    var sleep = require('system-sleep');
+    var request = require("request");
+    var cheerio = require('cheerio');
+    var jsesc = require('jsesc');
+    const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
 
-var url = [],
-    musicians = [];
-url.push("http://dbpedia.org/page/Category:21st-century_classical_musicians");
-url.push("http://dbpedia.org/page/Category:20th-century_classical_musicians");
-url.push("http://dbpedia.org/page/Category:19th-century_classical_musicians");
-url.push("http://dbpedia.org/page/Category:18th-century_classical_musicians");
-url.push("http://dbpedia.org/page/Category:17th-century_classical_musicians");
-console.log("---dbpedia_Classical_musicians_by_century.js started!---")
+    var url = [],
+        musicians = [];
+    url.push("http://dbpedia.org/page/Category:21st-century_classical_musicians");
+    url.push("http://dbpedia.org/page/Category:20th-century_classical_musicians");
+    url.push("http://dbpedia.org/page/Category:19th-century_classical_musicians");
+    url.push("http://dbpedia.org/page/Category:18th-century_classical_musicians");
+    url.push("http://dbpedia.org/page/Category:17th-century_classical_musicians");
+    console.log("---dbpedia_Classical_musicians_by_century.js started!---")
 
-var counter = 0
-url.forEach(function (value) {
-    scrapeCategory(value, function () {
-        counter++;
-        if (counter == url.length) {
-            var json2 = JSON.stringify(musicians); //convert it back to json
-            fs.writeFileSync('./scrapedoutput/artists/dbpedia_Classical_musicians_by_century.json', json2, 'utf8'); // write it back
-            process.send("done dbpedia_Classical_musicians_by_century.js");
-        }
-    });
-});
-
-
-function scrapeCategory(link1, callback) {
-    request(link1, function (error, response, body) {
-        var source_link = []
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_century.js scrapeCategory: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-
-        $('a[rev="dct:subject"]').each(function (i, element) {
-            var a = $(this);
-            source_link.push(a.attr('href'));
+    var counter = 0
+    url.forEach(function (value) {
+        scrapeCategory(value, function () {
+            counter++;
+            if (counter == url.length) {
+                var json2 = JSON.stringify(musicians); //convert it back to json
+                fs.writeFileSync('./scrapedoutput/artists/dbpedia_Classical_musicians_by_century.json', json2, 'utf8'); // write it back
+                returnToMaster();
+            }
         });
-
-        source_link.forEach(function (value) {
-            scrapeArtist(value);
-            sleep(1000);
-        });
-        callback();
-
-
     });
-}
 
 
-function scrapeArtist(source_link) {
-    request(jsesc(source_link), function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_century.js scrapeArtist: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        var split_name = (replaceURLAndUnderscore(source_link)).split("(");
+    function scrapeCategory(link1, callback) {
 
-        var nationality = $('span[property="dbo:nationality"]').text().trim();
-        if (nationality.length == 0)
-            nationality = null;
-
-        var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
-
-        var scrapedData = scrapedbpediaProperties($);
-
-        //only add artist if he hasn't been added
-        if (!musicians.some(function (element) {
-                return element.source_link == source_link;
-            })) {
-
-            musicians.push({
-                name: split_name[0].trim(),
-                artist_type: 'musician',
-                nationality: nationality,
-                source_link: source_link,
-                dateOfBirth: scrapedData.dateOfBirth,
-                dateOfDeath: scrapedData.dateOfDeath,
-                placeOfBirth: scrapedData.placeOfBirth,
-                placeOfDeath: scrapedData.placeOfDeath,
-                instrument: scrapedData.instrument,
-                pseudonym: scrapedData.pseudonym,
-                work: scrapedData.work,
-                release: scrapedData.release,
-                tags: scrapedData.tags,
-                wiki_link: scrapedData.wiki_link,
-                wiki_pageid: scrapedData.wiki_pageid
-
-
+        request(link1, function (error, response, body) {
+            var source_link = []
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_century.js scrapeCategory: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            $('a[rev="dct:subject"]').each(function (i, element) {
+                var a = $(this);
+                source_link.push(a.attr('href'));
             });
-        }
-    });
+
+            source_link.forEach(function (value) {
+                sleep(1000);
+                scrapeArtist(value);
+            });
+            callback();
+
+
+        });
+    }
+
+
+    function scrapeArtist(source_link) {
+        console.log("dbpedia_Classical_musicians_by_century.js scraping artist");
+        request(jsesc(source_link), function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_century.js scrapeArtist: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            var split_name = (replaceURLAndUnderscore(source_link)).split("(");
+
+            var nationality = $('span[property="dbo:nationality"]').text().trim();
+            if (nationality.length == 0)
+                nationality = null;
+
+            var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+
+            var scrapedData = scrapedbpediaProperties($);
+
+            //only add artist if he hasn't been added
+            if (!musicians.some(function (element) {
+                    return element.source_link == source_link;
+                })) {
+
+                musicians.push({
+                    name: split_name[0].trim(),
+                    artist_type: 'musician',
+                    nationality: nationality,
+                    source_link: source_link,
+                    dateOfBirth: scrapedData.dateOfBirth,
+                    dateOfDeath: scrapedData.dateOfDeath,
+                    placeOfBirth: scrapedData.placeOfBirth,
+                    placeOfDeath: scrapedData.placeOfDeath,
+                    instrument: scrapedData.instrument,
+                    pseudonym: scrapedData.pseudonym,
+                    work: scrapedData.work,
+                    release: scrapedData.release,
+                    tags: scrapedData.tags,
+                    wiki_link: scrapedData.wiki_link,
+                    wiki_pageid: scrapedData.wiki_pageid
+
+
+                });
+            }
+        });
+    }
 }
+

--- a/dbpedia/dbpedia_Classical_musicians_by_century.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_century.js
@@ -99,5 +99,5 @@ module.exports = function (returnToMaster) {
             }
         });
     }
-}
+};
 

--- a/dbpedia/dbpedia_Classical_musicians_by_instrument.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_instrument.js
@@ -101,4 +101,4 @@ module.exports = function (returnToMaster) {
             });
         });
     }
-}
+};

--- a/dbpedia/dbpedia_Classical_musicians_by_instrument.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_instrument.js
@@ -1,101 +1,104 @@
 /////////////////////EXTRACTS ALL CLASSICAL MUSICIANS BY INSTRUMENT///////////////
-var fs = require('fs');
-var sleep = require('system-sleep');
-var request = require("request");
-var cheerio = require('cheerio');
-var jsesc = require('jsesc');
-const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
-var temp_list = [],
-    source_link = [],
-    musicians = [],
-    url = [];
-url.push("http://dbpedia.org/page/Category:Classical_musicians_by_instrument");
-console.log("---dbpedia_Classical_musicians_by_instrument.js started!---")
+module.exports = function (returnToMaster) {
+    var fs = require('fs');
+    var sleep = require('system-sleep');
+    var request = require("request");
+    var cheerio = require('cheerio');
+    var jsesc = require('jsesc');
+    const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
+    var temp_list = [],
+        source_link = [],
+        musicians = [],
+        url = [];
+    url.push("http://dbpedia.org/page/Category:Classical_musicians_by_instrument");
+    console.log("---dbpedia_Classical_musicians_by_instrument.js started!---")
 
-url.forEach(function (value) {
-    scrapeURL(value);
-});
-
-function scrapeURL(link1) {
-    request(link1, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument.js scrapeURL: " + error);
-            return
-        }
-
-        $ = cheerio.load(body);
-        $('a[rev="skos:broader"]').each(function (i, element) {
-            var a = $(this);
-            temp_list.push(a.attr('href'));
-        });
-
-        temp_list.forEach(function (value) {
-            scrapeCat(value);
-            sleep(2000);
-
-        });
-        source_link.forEach(function (value) {
-            scrapeArtist(value);
-            sleep(1000);
-        });
-        json2 = JSON.stringify(musicians); //convert it back to json
-        fs.writeFileSync('./scrapedoutput/artists/dbpedia_Classical_musicians_by_instruments.json', json2, 'utf8'); // write it back
-        process.send("done dbpedia_Classical_musicians_by_instrument.js");
-
-
+    url.forEach(function (value) {
+        scrapeURL(value);
     });
-}
+
+    function scrapeURL(link1) {
+        request(link1, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument.js scrapeURL: " + error);
+                return
+            }
+
+            $ = cheerio.load(body);
+            $('a[rev="skos:broader"]').each(function (i, element) {
+                var a = $(this);
+                temp_list.push(a.attr('href'));
+            });
+
+            temp_list.forEach(function (value) {
+                scrapeCat(value);
+                sleep(2000);
+
+            });
+            source_link.forEach(function (value) {
+                scrapeArtist(value);
+                sleep(1000);
+            });
+            json2 = JSON.stringify(musicians); //convert it back to json
+            fs.writeFileSync('./scrapedoutput/artists/dbpedia_Classical_musicians_by_instruments.json', json2, 'utf8'); // write it back
+            returnToMaster();
 
 
-function scrapeCat(value2) {
-    request(value2, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument.js scrapeCat: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        $('a[rev="dct:subject"]').each(function (i, element) {
-            var a = $(this);
-            source_link.push(a.attr('href'));
         });
-
-    });
-}
+    }
 
 
-function scrapeArtist(value2) {
-    request(jsesc(value2), function (error, response, body) {
+    function scrapeCat(value2) {
+        request(value2, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument.js scrapeCat: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            $('a[rev="dct:subject"]').each(function (i, element) {
+                var a = $(this);
+                source_link.push(a.attr('href'));
+            });
 
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument.js scrapeArtist: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        var split_name = (replaceURLAndUnderscore(value2)).split("(");
-        var nationality = $('span[property="dbo:nationality"]').text().trim();
-        if (nationality.length == 0)
-            nationality = null;
-
-        var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
-
-        var scrapedData = scrapedbpediaProperties($);
-
-        musicians.push({
-            name: split_name[0].trim(),
-            artist_type: 'musician',
-            nationality: nationality,
-            source_link: value2,
-            dateOfBirth: scrapedData.dateOfBirth,
-            dateOfDeath: scrapedData.dateOfDeath,
-            placeOfBirth: scrapedData.placeOfBirth,
-            placeOfDeath: scrapedData.placeOfDeath,
-            instrument: scrapedData.instrument,
-            pseudonym: scrapedData.pseudonym,
-            work: scrapedData.work,
-            release: scrapedData.release,
-            tags: scrapedData.tags,
-            wiki_link: scrapedData.wiki_link,
-            wiki_pageid: scrapedData.wiki_pageid
         });
-    });
+    }
+
+
+    function scrapeArtist(value2) {
+        console.log("dbpedia_Classical_musicians_by_instrument.js scraping artist");
+        request(jsesc(value2), function (error, response, body) {
+
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument.js scrapeArtist: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            var split_name = (replaceURLAndUnderscore(value2)).split("(");
+            var nationality = $('span[property="dbo:nationality"]').text().trim();
+            if (nationality.length == 0)
+                nationality = null;
+
+            var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+
+            var scrapedData = scrapedbpediaProperties($);
+
+            musicians.push({
+                name: split_name[0].trim(),
+                artist_type: 'musician',
+                nationality: nationality,
+                source_link: value2,
+                dateOfBirth: scrapedData.dateOfBirth,
+                dateOfDeath: scrapedData.dateOfDeath,
+                placeOfBirth: scrapedData.placeOfBirth,
+                placeOfDeath: scrapedData.placeOfDeath,
+                instrument: scrapedData.instrument,
+                pseudonym: scrapedData.pseudonym,
+                work: scrapedData.work,
+                release: scrapedData.release,
+                tags: scrapedData.tags,
+                wiki_link: scrapedData.wiki_link,
+                wiki_pageid: scrapedData.wiki_pageid
+            });
+        });
+    }
 }

--- a/dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js
@@ -1,149 +1,151 @@
 /////////////////////EXTRACTS ALL CLASSICAL MUSICIANS BY INSTRUMENTS AND NATIONALITY///////////////
-var fs = require('fs');
-var sleep = require('system-sleep');
-var request = require("request");
-var cheerio = require('cheerio');
-var jsesc = require('jsesc');
-const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
+module.exports = function (returnToMaster) {
+    var fs = require('fs');
+    var sleep = require('system-sleep');
+    var request = require("request");
+    var cheerio = require('cheerio');
+    var jsesc = require('jsesc');
+    const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
 
-var musicians = [],
-    temp_list = [],
-    temp_list1 = [],
-    temp_list2 = [],
-    temp_list3 = [],
-    source_link = [],
-    source_sub_link = [];
-var url = [],
-    k = 1;
+    var musicians = [],
+        temp_list = [],
+        temp_list1 = [],
+        temp_list2 = [],
+        temp_list3 = [],
+        source_link = [],
+        source_sub_link = [];
+    var url = [],
+        k = 1;
 
 
-url.push("http://dbpedia.org/page/Category:Classical_musicians_by_instrument_and_nationality");
-console.log("---dbpedia_Classical_musicians_by_instrument_and_nationality.js started!---")
+    url.push("http://dbpedia.org/page/Category:Classical_musicians_by_instrument_and_nationality");
+    console.log("---dbpedia_Classical_musicians_by_instrument_and_nationality.js started!---")
 
-url.forEach(function (value) {
-    scrapeURL(value);
-});
-
-function scrapeURL(link1) {
-    request(link1, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeURL: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        $('a[rev="skos:broader"]').each(function (i, element) {
-            var a = $(this);
-            temp_list.push(a.attr('href'));
-        });
-        temp_list1 = temp_list;
-        temp_list = [];
-
-        temp_list1.forEach(function (value) {
-            scrapeMainCat(value);
-            sleep(2000);
-
-        });
-        temp_list2 = temp_list;
-        temp_list = [];
-
-        temp_list2.forEach(function (value) {
-            scrapeMainCat(value);
-            sleep(1000);
-        });
-
-        temp_list3 = temp_list;
-        temp_list = [];
-
-        temp_list3.forEach(function (value) {
-            scrapeSubCat(value);
-            sleep(1000);
-        });
-
-        source_link.forEach(function (value) {
-            scrapeArtist(value);
-            sleep(1000);
-        });
-        jsonOutput = JSON.stringify(musicians); //convert it back to json
-        fs.writeFileSync("./scrapedoutput/artists/dbpedia_Classical_musicians_by_instruments_and_nationality.json", jsonOutput, 'utf8'); // write it back
-        process.send("done dbpedia_Classical_musicians_by_instrument_and_nationality.js");
-
+    url.forEach(function (value) {
+        scrapeURL(value);
     });
-}
 
-
-function scrapeMainCat(value2) {
-    request(value2, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeMainCat: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        $('a[rev="skos:broader"]').each(function (i, element) {
-            var a = $(this);
-            temp_list.push(a.attr('href'));
-        });
-
-    });
-}
-
-function scrapeSubCat(linkNationality) {
-    request(linkNationality, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeSubCat: " + error);
-            return
-        }
-        $ = cheerio.load(body);
-        $('a[rev="dct:subject"]').each(function (i, element) {
-            var a = $(this);
-            var nationality = linkNationality.replace("http://dbpedia.org/page/Category:", "").replace("http://dbpedia.org/resource/Category:", "");
-            nationality = nationality.slice(0, nationality.indexOf("classical")).replace(new RegExp("_", 'g'), "").replace("fortepianist", "");
-            source_link.push({
-                linkMusician: a.attr('href'),
-                nationality: nationality
+    function scrapeURL(link1) {
+        request(link1, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeURL: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            $('a[rev="skos:broader"]').each(function (i, element) {
+                var a = $(this);
+                temp_list.push(a.attr('href'));
             });
+            temp_list1 = temp_list;
+            temp_list = [];
+            temp_list1.forEach(function (value) {
+                scrapeMainCat(value);
+                sleep(2000);
+
+            });
+            temp_list2 = temp_list;
+            temp_list = [];
+
+            temp_list2.forEach(function (value) {
+                scrapeMainCat(value);
+                sleep(1000);
+            });
+
+            temp_list3 = temp_list;
+            temp_list = [];
+
+            temp_list3.forEach(function (value) {
+                scrapeSubCat(value);
+                sleep(1000);
+            });
+
+            source_link.forEach(function (value) {
+                scrapeArtist(value);
+                sleep(1000);
+            });
+            jsonOutput = JSON.stringify(musicians); //convert it back to json
+            fs.writeFileSync("./scrapedoutput/artists/dbpedia_Classical_musicians_by_instruments_and_nationality.json", jsonOutput, 'utf8'); // write it back
+            returnToMaster();
+
         });
-
-    });
-}
-
-function scrapeArtist(linkMusicianAndNationality) {
-    request(jsesc(linkMusicianAndNationality.linkMusician), function (error, response, body) {
-
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeArtist: " + error);
-            return
-        }
-
-        $ = cheerio.load(body);
-
-        var split_name = (replaceURLAndUnderscore(linkMusicianAndNationality.linkMusician)).split("(");
-        var nationality = linkMusicianAndNationality.nationality;
-        if (nationality.length == 0)
-            nationality = null;
-
-        var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
-
-        var scrapedData = scrapedbpediaProperties($);
+    }
 
 
-        musicians.push({
-            name: split_name[0].trim(),
-            artist_type: 'musician',
-            nationality: nationality,
-            source_link: linkMusicianAndNationality,
-            dateOfBirth: scrapedData.dateOfBirth,
-            dateOfDeath: scrapedData.dateOfDeath,
-            placeOfBirth: scrapedData.placeOfBirth,
-            placeOfDeath: scrapedData.placeOfDeath,
-            instrument: scrapedData.instrument,
-            pseudonym: scrapedData.pseudonym,
-            work: scrapedData.work,
-            release: scrapedData.release,
-            tags: scrapedData.tags,
-            wiki_link: scrapedData.wiki_link,
-            wiki_pageid: scrapedData.wiki_pageid
+    function scrapeMainCat(value2) {
+        request(value2, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeMainCat: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            $('a[rev="skos:broader"]').each(function (i, element) {
+                var a = $(this);
+                temp_list.push(a.attr('href'));
+            });
+
         });
+    }
+
+    function scrapeSubCat(linkNationality) {
+        request(linkNationality, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeSubCat: " + error);
+                return
+            }
+            $ = cheerio.load(body);
+            $('a[rev="dct:subject"]').each(function (i, element) {
+                var a = $(this);
+                var nationality = linkNationality.replace("http://dbpedia.org/page/Category:", "").replace("http://dbpedia.org/resource/Category:", "");
+                nationality = nationality.slice(0, nationality.indexOf("classical")).replace(new RegExp("_", 'g'), "").replace("fortepianist", "");
+                source_link.push({
+                    linkMusician: a.attr('href'),
+                    nationality: nationality
+                });
+            });
+
+        });
+    }
+
+    function scrapeArtist(linkMusicianAndNationality) {
+        console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scraping artist");
+        request(jsesc(linkMusicianAndNationality.linkMusician), function (error, response, body) {
+
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_instrument_and_nationality.js scrapeArtist: " + error);
+                return
+            }
+
+            $ = cheerio.load(body);
+
+            var split_name = (replaceURLAndUnderscore(linkMusicianAndNationality.linkMusician)).split("(");
+            var nationality = linkMusicianAndNationality.nationality;
+            if (nationality.length == 0)
+                nationality = null;
+
+            var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+
+            var scrapedData = scrapedbpediaProperties($);
 
 
-    });
+            musicians.push({
+                name: split_name[0].trim(),
+                artist_type: 'musician',
+                nationality: nationality,
+                source_link: linkMusicianAndNationality,
+                dateOfBirth: scrapedData.dateOfBirth,
+                dateOfDeath: scrapedData.dateOfDeath,
+                placeOfBirth: scrapedData.placeOfBirth,
+                placeOfDeath: scrapedData.placeOfDeath,
+                instrument: scrapedData.instrument,
+                pseudonym: scrapedData.pseudonym,
+                work: scrapedData.work,
+                release: scrapedData.release,
+                tags: scrapedData.tags,
+                wiki_link: scrapedData.wiki_link,
+                wiki_pageid: scrapedData.wiki_pageid
+            });
+
+
+        });
+    }
 }

--- a/dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_instrument_and_nationality.js
@@ -148,4 +148,4 @@ module.exports = function (returnToMaster) {
 
         });
     }
-}
+};

--- a/dbpedia/dbpedia_Classical_musicians_by_nationality.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_nationality.js
@@ -1,103 +1,106 @@
-var request = require('request');
-var cheerio = require('cheerio');
-var sleep = require('system-sleep');
-var fs = require('fs');
-var jsesc = require('jsesc');
-const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
-const url = "http://dbpedia.org/page/Category:Classical_musicians_by_nationality";
+module.exports = function (returnToMaster) {
+    var request = require('request');
+    var cheerio = require('cheerio');
+    var sleep = require('system-sleep');
+    var fs = require('fs');
+    var jsesc = require('jsesc');
+    const replaceURLAndUnderscore = require('./helper/replaceURLAndUnderscore');
+    const url = "http://dbpedia.org/page/Category:Classical_musicians_by_nationality";
 
-const outputFile = "./scrapedoutput/artists/dbpedia_Classical_musicians_by_nationality.json";
-console.log("---dbpedia_Classical_musicians_by_nationality.js started!---")
-var musicians = [];
+    const outputFile = "./scrapedoutput/artists/dbpedia_Classical_musicians_by_nationality.json";
+    console.log("---dbpedia_Classical_musicians_by_nationality.js started!---")
+    var musicians = [];
 
 //Delete outputfile if it already exists
-fs.unlink(outputFile, scrapeMainCat);
+    fs.unlink(outputFile, scrapeMainCat);
 
-function scrapeMainCat() {
-    //request http://dbpedia.org/page/Category:Classical_musicians_by_nationality
-    request(url, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_nationality.js scrapeMainCat: " + error);
-            return
-        }
-        var $ = cheerio.load(body);
-        // iterate through all of the nation_classical_composers, i.e. german_classical_composers, american_classical_composers, ...
-        iterateSubCat($);
-    })
-}
+    function scrapeMainCat() {
+        //request http://dbpedia.org/page/Category:Classical_musicians_by_nationality
+        request(url, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_nationality.js scrapeMainCat: " + error);
+                return
+            }
+            var $ = cheerio.load(body);
+            // iterate through all of the nation_classical_composers, i.e. german_classical_composers, american_classical_composers, ...
+            iterateSubCat($);
+        })
+    }
 
-function iterateSubCat($, callback) {
-    var catArray = [];
-    $('a[rev="skos:broader"]').each(function () {
-        catArray.push($(this).attr('href'));
-    });
-
-    catArray.forEach(function (link) {
-        sleep(1000);
-        checkCat(link);
-
-    });
-    jsonEntry = JSON.stringify(musicians);
-    fs.writeFileSync(outputFile, jsonEntry, 'utf8');
-    process.send("done dbpedia_Classical_musicians_by_nationality.js");
-
-}
-
-function checkCat(linkNationality) {
-    // go to the link of nation_classical_composers
-    request(linkNationality, function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_nationality.js checkCat: " + error);
-            return
-        }
-
-        var $ = cheerio.load(body);
-        //iterate through all of the musicians, i.e. Mozart, Brahms, ...
-        $('a[rev="dct:subject"]').each(function (index) {
-            sleep(1000);
-            var linkMusician = $(this).attr('href');
-            // go to the link of the musician
-            checkArtist(linkMusician, linkNationality);
+    function iterateSubCat($, callback) {
+        var catArray = [];
+        $('a[rev="skos:broader"]').each(function () {
+            catArray.push($(this).attr('href'));
         });
 
-    })
-}
+        catArray.forEach(function (link) {
+            sleep(1000);
+            checkCat(link);
 
-function checkArtist(linkMusician, linkNationality) {
-    request(jsesc(linkMusician), function (error, response, body) {
-        if (error) {
-            console.log("dbpedia_Classical_musicians_by_nationality.js checkArtist: " + error);
-            return
-        }
+        });
+        jsonEntry = JSON.stringify(musicians);
+        fs.writeFileSync(outputFile, jsonEntry, 'utf8');
+        returnToMaster();
 
-        var $ = cheerio.load(body);
-        //extract infos
-        var name = replaceURLAndUnderscore(linkMusician).split("(");
+    }
 
-        var nationality = linkNationality.replace("http://dbpedia.org/page/Category:", "").replace("http://dbpedia.org/resource/Category:", "").replace("_classical_musicians", "");
-        if (nationality.length == 0)
-            nationality = null;
+    function checkCat(linkNationality) {
+        // go to the link of nation_classical_composers
+        request(linkNationality, function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_nationality.js checkCat: " + error);
+                return
+            }
 
-        var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+            var $ = cheerio.load(body);
+            //iterate through all of the musicians, i.e. Mozart, Brahms, ...
+            $('a[rev="dct:subject"]').each(function (index) {
+                sleep(1000);
+                var linkMusician = $(this).attr('href');
+                // go to the link of the musician
+                checkArtist(linkMusician, linkNationality);
+            });
 
-        var scrapedData = scrapedbpediaProperties($);
-
-        musicians.push({
-            name: name[0].trim(),
-            artist_type: 'musician',
-            nationality: nationality,
-            source_link: linkMusician,
-            dateOfBirth: scrapedData.dateOfBirth,
-            dateOfDeath: scrapedData.dateOfDeath,
-            placeOfBirth: scrapedData.placeOfBirth,
-            placeOfDeath: scrapedData.placeOfDeath,
-            instrument: scrapedData.instrument,
-            pseudonym: scrapedData.pseudonym,
-            work: scrapedData.work,
-            release: scrapedData.release,
-            tags: scrapedData.tags,
-            wiki_link: scrapedData.wiki_link,
-            wiki_pageid: scrapedData.wiki_pageid
         })
-    })
+    }
+
+    function checkArtist(linkMusician, linkNationality) {
+        console.log("dbpedia_Classical_musicians_by_nationality.js scraping artist");
+        request(jsesc(linkMusician), function (error, response, body) {
+            if (error) {
+                console.log("dbpedia_Classical_musicians_by_nationality.js checkArtist: " + error);
+                return
+            }
+
+            var $ = cheerio.load(body);
+            //extract infos
+            var name = replaceURLAndUnderscore(linkMusician).split("(");
+
+            var nationality = linkNationality.replace("http://dbpedia.org/page/Category:", "").replace("http://dbpedia.org/resource/Category:", "").replace("_classical_musicians", "");
+            if (nationality.length == 0)
+                nationality = null;
+
+            var scrapedbpediaProperties = require('./helper/scrapedbpediaProperties.js');
+
+            var scrapedData = scrapedbpediaProperties($);
+
+            musicians.push({
+                name: name[0].trim(),
+                artist_type: 'musician',
+                nationality: nationality,
+                source_link: linkMusician,
+                dateOfBirth: scrapedData.dateOfBirth,
+                dateOfDeath: scrapedData.dateOfDeath,
+                placeOfBirth: scrapedData.placeOfBirth,
+                placeOfDeath: scrapedData.placeOfDeath,
+                instrument: scrapedData.instrument,
+                pseudonym: scrapedData.pseudonym,
+                work: scrapedData.work,
+                release: scrapedData.release,
+                tags: scrapedData.tags,
+                wiki_link: scrapedData.wiki_link,
+                wiki_pageid: scrapedData.wiki_pageid
+            })
+        })
+    }
 }

--- a/dbpedia/dbpedia_Classical_musicians_by_nationality.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_nationality.js
@@ -103,4 +103,4 @@ module.exports = function (returnToMaster) {
             });
         })
     }
-}
+};

--- a/dbpedia/dbpedia_Classical_musicians_by_nationality.js
+++ b/dbpedia/dbpedia_Classical_musicians_by_nationality.js
@@ -100,7 +100,7 @@ module.exports = function (returnToMaster) {
                 tags: scrapedData.tags,
                 wiki_link: scrapedData.wiki_link,
                 wiki_pageid: scrapedData.wiki_pageid
-            })
+            });
         })
     }
 }


### PR DESCRIPTION
One can now specify the number of threads/cpus that should be used for scraping, i.e.
`node cli.js -s dbpedia -t 4`
will use 4 cpus. If this parameter is omitted, the script will use all available cpus.